### PR TITLE
Cast the request body to string

### DIFF
--- a/src/Client/Client.php
+++ b/src/Client/Client.php
@@ -29,7 +29,7 @@ class Client implements ClientInterface
         return Http::withHeaders($headers)
             ->timeout($timeout)
             ->connectTimeout($connectTimeout)
-            ->withBody($request->getBody()->getContents(), $contentType)
+            ->withBody((string) $request->getBody(), $contentType)
             ->send($request->getMethod(), $request->getUri())
             ->toPsrResponse();
     }


### PR DESCRIPTION
The `__toString` method of the StreamInterface reads all the content of the body while `getContents` only returns the remaining contents of the string.

If the position of the stream is not reset, it may not return any data at all.